### PR TITLE
Switch iteritems to items for Py3 compatibility

### DIFF
--- a/django_baker/templates/django_baker/__init__urls
+++ b/django_baker/templates/django_baker/__init__urls
@@ -1,6 +1,6 @@
 from django.conf.urls import patterns, include
 
 urlpatterns = patterns('',
-{% for model_name_slug, plural_model_name_slug in model_names_dict.iteritems %}
+{% for model_name_slug, plural_model_name_slug in model_names_dict.items %}
     (r'^{{ plural_model_name_slug }}/', include('{{ app_label }}.urls.{{ model_name_slug }}_urls')),{% if forloop.first %}  # NOQA{% endif %}{% endfor %}
 )

--- a/django_baker/templates/django_baker/forms
+++ b/django_baker/templates/django_baker/forms
@@ -1,7 +1,7 @@
 from django import forms
 from .models import {{ model_names|join:", " }}
 
-{% for model_name, model_fields in model_names.iteritems %}
+{% for model_name, model_fields in model_names.items %}
 class {{ model_name }}Form(forms.ModelForm):
 
     class Meta:


### PR DESCRIPTION
Under python 3, the forms and urls are not rendered correctly, as .iteritems() was replaced with .items().