### PR TITLE
mark_safe is added to create links between tables.

### DIFF
--- a/django_baker/admin.py
+++ b/django_baker/admin.py
@@ -1,6 +1,7 @@
 from django.core.validators import URLValidator
 from django.db.models.fields import FieldDoesNotExist
 from django.utils.encoding import smart_text
+from django.utils.safestring import mark_safe
 
 from functools import partial
 
@@ -95,8 +96,8 @@ class ExtendedModelAdminMixin(object):
             target = getattr(instance, field)
             if not target:
                 return "None"
-            return u'<a href="../../%s/%s/%d">%s</a>' % (
-                target._meta.app_label, target._meta.model_name, target.id, smart_text(target))
+            return mark_safe(u'<a href="../../%s/%s/%d">%s</a>' % (
+                target._meta.app_label, target._meta.model_name, target.id, smart_text(target)))
 
         if name[:9] == 'url_link_':
             method = partial(url_link, field=name[9:])


### PR DESCRIPTION
When the tables are checked in the django admin panel, the foreign key links were broken and values were looking like this:

<a href="../../database/test_table/1">test</a>

In order to fix this issue, mark_safe is added to 'foreign_key_link' method.