### PR TITLE
Update FieldDoesNotExist in admin.py

### DIFF
--- a/django_baker/admin.py
+++ b/django_baker/admin.py
@@ -1,5 +1,5 @@
 from django.core.validators import URLValidator
-from django.db.models.fields import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist
 from django.utils.encoding import smart_text
 
 from functools import partial


### PR DESCRIPTION
FieldDoesNotExist needs to be defined differently in current versions.
It can now be found in the django.core.exceptions