### PR TITLE
Update six in bakery.py

### DIFF
--- a/django_baker/bakery.py
+++ b/django_baker/bakery.py
@@ -7,7 +7,7 @@ import itertools
 from django.db.models.fields import SlugField
 from django.template.loader import get_template
 from django.template import Context
-from django.utils.six import iteritems
+from six import iteritems
 
 
 class Baker(object):


### PR DESCRIPTION
six is required and therefore needs to be updated to work with recent versions.
Looks like all of this already has been suggested before.